### PR TITLE
Correct auth token Airflow Variable name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ The cost attribution DAGs can be found in the /dags folder of this repository.
 
 The following steps will help you get started:
 
-1. Copy and paste the snowflake_cost_attribution DAG file into your existing Astro project in the same folder where the rest of your DAGs are located. 
+1. Copy and paste the snowflake_cost_attribution DAG file into your existing Astro project in the same folder where the rest of your DAGs are located.
 2. Then deploy that DAG to your existing Astro Hosted deployment (instructions here to install DAG in Astro Hosted https://www.astronomer.io/docs/astro/deploy-dags)
 3. Within your Astro Hosted deployment, you'll need to set up a few required environment variables. You can set this up by going clicking on Deployment > Environment tab:
     - `ASTRO_ORGANIZATION_ID`: Your Astronomer organization ID. If you don't know it, go to Organization > Organization Settings and you'll find it on the General page.
         - Set this under *Environment Variables*
-    - `AIRFLOW_VAR_AUTH_TOKEN`: API token for authenticating with Astronomer. This needs to be an Organization-level API key, not at the workspace or deployment level.
+    - `AUTH_TOKEN`: API token for authenticating with Astronomer. This needs to be an Organization-level API key, not at the workspace or deployment level.
         - To create one, navigate to Organization > Organization Settings > Access Management > API Tokens. Make sure the organization role is at least Organization Observe Admin.
         - Set this under *Airflow Variables*
 4. Verify your data warehouse connection
     - Snowflake: Setup a Snowflake connection if you haven't already under Deployment > Environment > Connections. Make sure the connection ID here matches the connection ID name used in the cost DAG (e.g. "snowflake"). If you'd like to change the connection ID name in the cost DAG, make sure to update the `conn_id` field in the `SQLExecuteQueryOperator` used in two places.
 5. Test the DAG
-    - Trigger the DAG manually either in Astro Hosted or the Airflow UI to ensure the DAG executes successfully. Monitor the task execution in the Graph View or logs to verify successful execution.  
+    - Trigger the DAG manually either in Astro Hosted or the Airflow UI to ensure the DAG executes successfully. Monitor the task execution in the Graph View or logs to verify successful execution.
 


### PR DESCRIPTION
Related: #1

Recently, the Airflow Variable name where the auth token is stored was updated to better reflect Airflow naming semantics; however, the README wasn't updated -- just keeping these aligned.